### PR TITLE
Add support to SyntaxTree 6 and Mermaid.js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "bundler"
 gem "rake"
-gem "syntax_tree"
+gem "syntax_tree", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    prettier_print (1.2.0)
     rake (13.0.6)
-    syntax_tree (2.3.1)
+    syntax_tree (6.0.0)
+      prettier_print (>= 1.2.0)
 
 PLATFORMS
   ruby
@@ -12,7 +14,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   rake
-  syntax_tree
+  syntax_tree (~> 6.0)
 
 BUNDLED WITH
    2.3.6

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ To run the application locally, you should:
 * `yarn serve` to start the local development server.
 * Open a browser at `localhost:8000`.
 
+_In order to build package using linux you should set the env CI=1 along with the rake execution. `CI=1 bundle exec rake`_
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/ruby-syntax-tree/syntax_tree.

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 file "wasi-vfs" do
-  version = "0.1.1"
+  version = "0.2.0"
   filename =
     if ENV["CI"]
       "wasi-vfs-cli-x86_64-unknown-linux-gnu.zip"
@@ -19,7 +19,7 @@ file "head-wasm32-unknown-wasi-full-js" do
   version = JSON.parse(File.read("package.json"))["dependencies"]["ruby-head-wasm-wasi"][1..]
   filename = "ruby-head-wasm32-unknown-wasi-full-js.tar.gz"
 
-  `curl -LO https://github.com/ruby/ruby.wasm/releases/download/ruby-head-wasm-wasi-#{version}/#{filename}`
+  `curl -LO https://github.com/ruby/ruby.wasm/releases/download/ruby-head-wasm-wasi-#{version}/ruby-head-wasm32-unknown-wasi-full-js.tar.gz`
   `tar xfz #{filename}`
   rm filename
 end
@@ -30,7 +30,9 @@ end
 
 file "src/app.wasm" => ["Gemfile.lock", "wasi-vfs", "ruby.wasm"] do
   require "bundler/setup"
-  cp_r $:.find { _1.include?("syntax_tree") }, "lib"
+
+  cp_r $:.find { _1.include?("syntax_tree") }, "."
+  cp_r $:.find { _1.include?("prettier_print") }, "."
 
   `./wasi-vfs pack ruby.wasm --mapdir /lib::./lib --mapdir /usr::./head-wasm32-unknown-wasi-full-js/usr -o src/app.wasm`
   rm_rf "lib"

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ file "head-wasm32-unknown-wasi-full-js" do
   version = JSON.parse(File.read("package.json"))["dependencies"]["ruby-head-wasm-wasi"][1..]
   filename = "ruby-head-wasm32-unknown-wasi-full-js.tar.gz"
 
-  `curl -LO https://github.com/ruby/ruby.wasm/releases/download/ruby-head-wasm-wasi-#{version}/ruby-head-wasm32-unknown-wasi-full-js.tar.gz`
+  `curl -LO https://github.com/ruby/ruby.wasm/releases/download/ruby-head-wasm-wasi-#{version}/#{filename}`
   `tar xfz #{filename}`
   rm filename
 end

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,178 +16,22 @@
         <span><button type="button" id="format" disabled>Format</button></span>
 
         <div class="toggles">
-          <span><button type="button" value="prettyPrint" disabled>AST</button></span>
-          <span><button type="button" value="disasm" disabled>ISEQ</button></span>
+          <select>
+            <option value="prettyPrint">AST</option>
+            <option value="disasm">ISEQ</option>
+            <option value="mermaid">GRAPH</option>
+          </select>
         </div>
       </nav>
-      <textarea id="editor"># frozen_string_literal: true
-
-require "prettier_print"
-require "ripper"
-
-require_relative "syntax_tree/node"
-require_relative "syntax_tree/basic_visitor"
-require_relative "syntax_tree/visitor"
-
-require_relative "syntax_tree/formatter"
-require_relative "syntax_tree/parser"
-require_relative "syntax_tree/version"
-
-# Syntax Tree is a suite of tools built on top of the internal CRuby parser. It
-# provides the ability to generate a syntax tree from source, as well as the
-# tools necessary to inspect and manipulate that syntax tree. It can be used to
-# build formatters, linters, language servers, and more.
-module SyntaxTree
-  # Syntax Tree the library has many features that aren't always used by the
-  # CLI. Requiring those features takes time, so we autoload as many constants
-  # as possible in order to keep the CLI as fast as possible.
-
-  autoload :DSL, "syntax_tree/dsl"
-  autoload :FieldVisitor, "syntax_tree/field_visitor"
-  autoload :Index, "syntax_tree/index"
-  autoload :JSONVisitor, "syntax_tree/json_visitor"
-  autoload :LanguageServer, "syntax_tree/language_server"
-  autoload :MatchVisitor, "syntax_tree/match_visitor"
-  autoload :Mermaid, "syntax_tree/mermaid"
-  autoload :MermaidVisitor, "syntax_tree/mermaid_visitor"
-  autoload :MutationVisitor, "syntax_tree/mutation_visitor"
-  autoload :Pattern, "syntax_tree/pattern"
-  autoload :PrettyPrintVisitor, "syntax_tree/pretty_print_visitor"
-  autoload :Search, "syntax_tree/search"
-  autoload :Translation, "syntax_tree/translation"
-  autoload :WithScope, "syntax_tree/with_scope"
-  autoload :YARV, "syntax_tree/yarv"
-
-  # This holds references to objects that respond to both #parse and #format
-  # so that we can use them in the CLI.
-  HANDLERS = {}
-  HANDLERS.default = SyntaxTree
-
-  # This is the default print width when formatting. It can be overridden in the
-  # CLI by passing the --print-width option or here in the API by passing the
-  # optional second argument to ::format.
-  DEFAULT_PRINT_WIDTH = 80
-
-  # This is the default ruby version that we're going to target for formatting.
-  # It shouldn't really be changed except in very niche circumstances.
-  DEFAULT_RUBY_VERSION = Formatter::SemanticVersion.new(RUBY_VERSION).freeze
-
-  # The default indentation level for formatting. We allow changing this so
-  # that Syntax Tree can format arbitrary parts of a document.
-  DEFAULT_INDENTATION = 0
-
-  # Parses the given source and returns the formatted source.
-  def self.format(
-    source,
-    maxwidth = DEFAULT_PRINT_WIDTH,
-    base_indentation = DEFAULT_INDENTATION,
-    options: Formatter::Options.new
-  )
-    format_node(
-      source,
-      parse(source),
-      maxwidth,
-      base_indentation,
-      options: options
-    )
-  end
-
-  # Parses the given file and returns the formatted source.
-  def self.format_file(
-    filepath,
-    maxwidth = DEFAULT_PRINT_WIDTH,
-    base_indentation = DEFAULT_INDENTATION,
-    options: Formatter::Options.new
-  )
-    format(read(filepath), maxwidth, base_indentation, options: options)
-  end
-
-  # Accepts a node in the tree and returns the formatted source.
-  def self.format_node(
-    source,
-    node,
-    maxwidth = DEFAULT_PRINT_WIDTH,
-    base_indentation = DEFAULT_INDENTATION,
-    options: Formatter::Options.new
-  )
-    formatter = Formatter.new(source, [], maxwidth, options: options)
-    node.format(formatter)
-
-    formatter.flush(base_indentation)
-    formatter.output.join
-  end
-
-  # Indexes the given source code to return a list of all class, module, and
-  # method definitions. Used to quickly provide indexing capability for IDEs or
-  # documentation generation.
-  def self.index(source)
-    Index.index(source)
-  end
-
-  # Indexes the given file to return a list of all class, module, and method
-  # definitions. Used to quickly provide indexing capability for IDEs or
-  # documentation generation.
-  def self.index_file(filepath)
-    Index.index_file(filepath)
-  end
-
-  # A convenience method for creating a new mutation visitor.
-  def self.mutation
-    visitor = MutationVisitor.new
-    yield visitor
-    visitor
-  end
-
-  # Parses the given source and returns the syntax tree.
-  def self.parse(source)
-    parser = Parser.new(source)
-    response = parser.parse
-    response unless parser.error?
-  end
-
-  # Parses the given file and returns the syntax tree.
-  def self.parse_file(filepath)
-    parse(read(filepath))
-  end
-
-  # Returns the source from the given filepath taking into account any potential
-  # magic encoding comments.
-  def self.read(filepath)
-    encoding =
-      File.open(filepath, "r") do |file|
-        break Encoding.default_external if file.eof?
-
-        header = file.readline
-        header += file.readline if !file.eof? && header.start_with?("#!")
-        Ripper.new(header).tap(&:parse).encoding
-      end
-
-    File.read(filepath, encoding: encoding)
-  end
-
-  # This is a hook provided so that plugins can register themselves as the
-  # handler for a particular file type.
-  def self.register_handler(extension, handler)
-    HANDLERS[extension] = handler
-  end
-
-  # Searches through the given source using the given pattern and yields each
-  # node in the tree that matches the pattern to the given block.
-  def self.search(source, query, &block)
-    pattern = Pattern.new(query).compile
-    program = parse(source)
-
-    Search.new(pattern).scan(program, &block)
-  end
-
-  # Searches through the given file using the given pattern and yields each
-  # node in the tree that matches the pattern to the given block.
-  def self.search_file(filepath, query, &block)
-    search(read(filepath), query, &block)
-  end
-end
-</textarea>
+      <textarea id="editor">
+SyntaxTree::Binary[
+  left: SyntaxTree::Int[value: "1"],
+  operator: :+,
+  right: SyntaxTree::Int[value: "1"]
+]
+      </textarea>
       <textarea id="output" disabled readonly>Loading...</textarea>
+      <div id="graph-container" class="graph-container"></div>
     </main>
     <script type="module" src="index.js"></script>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,31 +22,120 @@
       </nav>
       <textarea id="editor"># frozen_string_literal: true
 
-require "json"
-require "pp"
-require "prettyprint"
+require "prettier_print"
 require "ripper"
-require "stringio"
+
+require_relative "syntax_tree/node"
+require_relative "syntax_tree/basic_visitor"
+require_relative "syntax_tree/visitor"
 
 require_relative "syntax_tree/formatter"
-require_relative "syntax_tree/node"
 require_relative "syntax_tree/parser"
-require_relative "syntax_tree/prettyprint"
 require_relative "syntax_tree/version"
-require_relative "syntax_tree/visitor"
-require_relative "syntax_tree/visitor/json_visitor"
-require_relative "syntax_tree/visitor/pretty_print_visitor"
 
+# Syntax Tree is a suite of tools built on top of the internal CRuby parser. It
+# provides the ability to generate a syntax tree from source, as well as the
+# tools necessary to inspect and manipulate that syntax tree. It can be used to
+# build formatters, linters, language servers, and more.
 module SyntaxTree
+  # Syntax Tree the library has many features that aren't always used by the
+  # CLI. Requiring those features takes time, so we autoload as many constants
+  # as possible in order to keep the CLI as fast as possible.
+
+  autoload :DSL, "syntax_tree/dsl"
+  autoload :FieldVisitor, "syntax_tree/field_visitor"
+  autoload :Index, "syntax_tree/index"
+  autoload :JSONVisitor, "syntax_tree/json_visitor"
+  autoload :LanguageServer, "syntax_tree/language_server"
+  autoload :MatchVisitor, "syntax_tree/match_visitor"
+  autoload :Mermaid, "syntax_tree/mermaid"
+  autoload :MermaidVisitor, "syntax_tree/mermaid_visitor"
+  autoload :MutationVisitor, "syntax_tree/mutation_visitor"
+  autoload :Pattern, "syntax_tree/pattern"
+  autoload :PrettyPrintVisitor, "syntax_tree/pretty_print_visitor"
+  autoload :Search, "syntax_tree/search"
+  autoload :Translation, "syntax_tree/translation"
+  autoload :WithScope, "syntax_tree/with_scope"
+  autoload :YARV, "syntax_tree/yarv"
+
   # This holds references to objects that respond to both #parse and #format
   # so that we can use them in the CLI.
   HANDLERS = {}
   HANDLERS.default = SyntaxTree
 
-  # This is a hook provided so that plugins can register themselves as the
-  # handler for a particular file type.
-  def self.register_handler(extension, handler)
-    HANDLERS[extension] = handler
+  # This is the default print width when formatting. It can be overridden in the
+  # CLI by passing the --print-width option or here in the API by passing the
+  # optional second argument to ::format.
+  DEFAULT_PRINT_WIDTH = 80
+
+  # This is the default ruby version that we're going to target for formatting.
+  # It shouldn't really be changed except in very niche circumstances.
+  DEFAULT_RUBY_VERSION = Formatter::SemanticVersion.new(RUBY_VERSION).freeze
+
+  # The default indentation level for formatting. We allow changing this so
+  # that Syntax Tree can format arbitrary parts of a document.
+  DEFAULT_INDENTATION = 0
+
+  # Parses the given source and returns the formatted source.
+  def self.format(
+    source,
+    maxwidth = DEFAULT_PRINT_WIDTH,
+    base_indentation = DEFAULT_INDENTATION,
+    options: Formatter::Options.new
+  )
+    format_node(
+      source,
+      parse(source),
+      maxwidth,
+      base_indentation,
+      options: options
+    )
+  end
+
+  # Parses the given file and returns the formatted source.
+  def self.format_file(
+    filepath,
+    maxwidth = DEFAULT_PRINT_WIDTH,
+    base_indentation = DEFAULT_INDENTATION,
+    options: Formatter::Options.new
+  )
+    format(read(filepath), maxwidth, base_indentation, options: options)
+  end
+
+  # Accepts a node in the tree and returns the formatted source.
+  def self.format_node(
+    source,
+    node,
+    maxwidth = DEFAULT_PRINT_WIDTH,
+    base_indentation = DEFAULT_INDENTATION,
+    options: Formatter::Options.new
+  )
+    formatter = Formatter.new(source, [], maxwidth, options: options)
+    node.format(formatter)
+
+    formatter.flush(base_indentation)
+    formatter.output.join
+  end
+
+  # Indexes the given source code to return a list of all class, module, and
+  # method definitions. Used to quickly provide indexing capability for IDEs or
+  # documentation generation.
+  def self.index(source)
+    Index.index(source)
+  end
+
+  # Indexes the given file to return a list of all class, module, and method
+  # definitions. Used to quickly provide indexing capability for IDEs or
+  # documentation generation.
+  def self.index_file(filepath)
+    Index.index_file(filepath)
+  end
+
+  # A convenience method for creating a new mutation visitor.
+  def self.mutation
+    visitor = MutationVisitor.new
+    yield visitor
+    visitor
   end
 
   # Parses the given source and returns the syntax tree.
@@ -56,13 +145,9 @@ module SyntaxTree
     response unless parser.error?
   end
 
-  # Parses the given source and returns the formatted source.
-  def self.format(source)
-    formatter = Formatter.new(source, [])
-    parse(source).format(formatter)
-
-    formatter.flush
-    formatter.output.join
+  # Parses the given file and returns the syntax tree.
+  def self.parse_file(filepath)
+    parse(read(filepath))
   end
 
   # Returns the source from the given filepath taking into account any potential
@@ -70,12 +155,35 @@ module SyntaxTree
   def self.read(filepath)
     encoding =
       File.open(filepath, "r") do |file|
+        break Encoding.default_external if file.eof?
+
         header = file.readline
-        header += file.readline if header.start_with?("#!")
+        header += file.readline if !file.eof? && header.start_with?("#!")
         Ripper.new(header).tap(&:parse).encoding
       end
 
     File.read(filepath, encoding: encoding)
+  end
+
+  # This is a hook provided so that plugins can register themselves as the
+  # handler for a particular file type.
+  def self.register_handler(extension, handler)
+    HANDLERS[extension] = handler
+  end
+
+  # Searches through the given source using the given pattern and yields each
+  # node in the tree that matches the pattern to the given block.
+  def self.search(source, query, &block)
+    pattern = Pattern.new(query).compile
+    program = parse(source)
+
+    Search.new(pattern).scan(program, &block)
+  end
+
+  # Searches through the given file using the given pattern and yields each
+  # node in the tree that matches the pattern to the given block.
+  def self.search_file(filepath, query, &block)
+    search(read(filepath), query, &block)
   end
 end
 </textarea>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,20 +16,14 @@
         <span><button type="button" id="format" disabled>Format</button></span>
 
         <div class="toggles">
-          <select>
+          <select disabled>
             <option value="prettyPrint">AST</option>
             <option value="disasm">ISEQ</option>
             <option value="mermaid">GRAPH</option>
           </select>
         </div>
       </nav>
-      <textarea id="editor">
-SyntaxTree::Binary[
-  left: SyntaxTree::Int[value: "1"],
-  operator: :+,
-  right: SyntaxTree::Int[value: "1"]
-]
-      </textarea>
+      <textarea id="editor">1 + 2 * 3</textarea>
       <textarea id="output" disabled readonly>Loading...</textarea>
       <div id="graph-container" class="graph-container"></div>
     </main>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@monaco-editor/loader": "^1.3.2",
     "@wasmer/wasi": "^0.12.0",
     "@wasmer/wasmfs": "^0.12.0",
+    "mermaid": "^9.4.0",
     "path-browserify": "^1.0.1",
     "ruby-head-wasm-wasi": "^0.3.0"
   },

--- a/src/createRuby.ts
+++ b/src/createRuby.ts
@@ -69,6 +69,7 @@ export default async function createRuby() {
     require "rubygems"
     require "did_you_mean"
     require "json"
+    require "pp"
     $:.unshift("/lib")
     require_relative "/lib/syntax_tree"
     require_relative "/lib/prettier_print"
@@ -94,10 +95,7 @@ export default async function createRuby() {
     // the syntax tree.
     prettyPrint(source: string) {
       const jsonSource = JSON.stringify(JSON.stringify(source));
-      const rubySource = `
-        source = JSON.parse(${jsonSource})
-        SyntaxTree.parse(source).pretty_inspect
-      `;
+      const rubySource = `PP.pp(SyntaxTree.parse(JSON.parse(${jsonSource})), +"", 80)`;
     
       return ruby.eval(rubySource).toString();
     }

--- a/src/createRuby.ts
+++ b/src/createRuby.ts
@@ -66,10 +66,12 @@ export default async function createRuby() {
   // files to make it work. I'm not sure why I need to explicitly require
   // did_you_mean here, but it doesn't work without it.
   ruby.eval(`
+    require "rubygems"
     require "did_you_mean"
     require "json"
     $:.unshift("/lib")
     require_relative "/lib/syntax_tree"
+    require_relative "/lib/prettier_print"
   `);
 
   return {
@@ -93,10 +95,8 @@ export default async function createRuby() {
     prettyPrint(source: string) {
       const jsonSource = JSON.stringify(JSON.stringify(source));
       const rubySource = `
-        PP.format([], 80) do |q|
-          source = JSON.parse(${jsonSource})
-          SyntaxTree.parse(source).pretty_print(q)
-        end.join
+        source = JSON.parse(${jsonSource})
+        SyntaxTree.parse(source).pretty_inspect
       `;
     
       return ruby.eval(rubySource).toString();

--- a/src/createRuby.ts
+++ b/src/createRuby.ts
@@ -83,6 +83,15 @@ export default async function createRuby() {
 
       return ruby.eval(rubySource).toString();
     },
+    mermaid(source: string) {
+      const jsonSource = JSON.stringify(JSON.stringify(source));
+      const rubySource = `
+        source = JSON.parse(${jsonSource})
+        SyntaxTree.parse(source).to_mermaid
+      `;
+
+      return ruby.eval(rubySource).toString();
+    },
     // A function that calls through to the SyntaxTree.format function to get
     // the pretty-printed version of the source.
     format(source: string) {

--- a/src/index.css
+++ b/src/index.css
@@ -48,3 +48,13 @@ textarea {
   resize: none;
   white-space: pre;
 }
+
+select {
+  min-width: 15em;
+}
+
+.graph-container {
+  text-align: center;
+  overflow-y: scroll;
+  overflow-x: scroll;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,4 +98,6 @@ Promise.all([
   format.addEventListener("click", () => {
     editor.setValue(ruby.format(editor.getValue()));
   });
+
+  toggles.querySelector("select").removeAttribute('disabled');
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import "./index.css";
 
 type SourceChangedEvent = { source: string };
-type DisplayChangedEvent = { kind: "prettyPrint" | "disasm" };
+type DisplayChangedEvent = { kind: "prettyPrint" | "disasm" | "mermaid" };
 
 Promise.all([
   // We're going to load the editor asynchronously so that we can get to
@@ -21,11 +21,12 @@ Promise.all([
       }
     });
   }),
+  import("./mermaid-js"),
   // We're going to load the Ruby VM chunk asynchronously because it is pretty
   // dang huge (> 40Mb). In the meantime the textarea that is holding the place
   // of the actual functional one is just going to display "Loading...".
   import("./createRuby").then(({ default: createRuby }) => createRuby())
-]).then(([editor, ruby]) => {
+]).then(([editor, mermaidjs, ruby]) => {
   // First, grab a reference to the output element so that we can update it.
   // Then, set it initially to the output represented by the source.
   const output = document.getElementById("output") as HTMLTextAreaElement;
@@ -41,7 +42,20 @@ Promise.all([
     displayFunction = ruby[event.detail.kind];
 
     try {
-      output.value = displayFunction(editor.getValue());
+      let source = displayFunction(editor.getValue());
+
+      if (event.detail.kind === 'mermaid') {
+        mermaidjs.render(() => {
+          output.setAttribute("style", "display: none;");
+
+          return source;
+        });
+      } else {
+        output.value = source;
+        output.setAttribute("style", "");
+
+        mermaidjs.reset();
+      }
     } catch (error) {
       // For now, just ignoring the error. Eventually I'd like to make this mark
       // an error state on the editor to give feedback to the user.
@@ -52,30 +66,20 @@ Promise.all([
   // event information.
   const toggles = document.getElementsByClassName("toggles")[0];
 
-  toggles.querySelectorAll("button").forEach((button) => {
-    button.disabled = (button.value === "prettyPrint");
-
-    button.addEventListener("click", () => {
-      toggles.querySelectorAll("button").forEach((toggle) => {
-        toggle.disabled = (button.value === toggle.value);
-      });
-
-      output.dispatchEvent(new CustomEvent<DisplayChangedEvent>("display-changed", {
-        detail: { kind: button.value as DisplayChangedEvent["kind"] }
-      }));
-    });
+  toggles.querySelector("select").addEventListener('change', (e) => {
+    output.dispatchEvent(new CustomEvent<DisplayChangedEvent>("display-changed", {
+      detail: { kind: e.target.value as DisplayChangedEvent["kind"] }
+    }));
   });
 
   // We're going to handle updates to the source through a custom event. This
   // turns out to be faster than handling the change event directly on the
   // editor since it blocks updates to the UI until the event handled returns.
   output.addEventListener("source-changed", (event: CustomEvent<SourceChangedEvent>) => {
-    try {
-      output.value = displayFunction(event.detail.source);
-    } catch (error) {
-      // For now, just ignoring the error. Eventually I'd like to make this mark
-      // an error state on the editor to give feedback to the user.
-    }
+    // We may want to add some throttle here to avoid to much rerendering in our Graph
+    output.dispatchEvent(new CustomEvent<DisplayChangedEvent>("display-changed", {
+      detail: { kind: toggles.querySelector('select').value as DisplayChangedEvent["kind"] }
+    }));
   });
 
   // Attach to the editor and dispatch custom source-changed events whenever the

--- a/src/mermaid-js.ts
+++ b/src/mermaid-js.ts
@@ -1,0 +1,24 @@
+import mermaidjs from "mermaid";
+
+const getCleanContainer = () => {
+  const div = document.querySelector("#graph-container");
+  
+  div.innerHTML = '';
+
+  return div;
+}
+
+const render = (fn: Function) => {
+  let container = getCleanContainer();
+
+  container.setAttribute("style", "display: block;");
+
+  mermaidjs.initialize({ startOnLoad: false });
+  mermaidjs.render('preparedScheme', fn(), (svg) => {
+    container.innerHTML = svg;
+  }, container);
+}
+
+const reset = () => getCleanContainer().setAttribute("style", "display: none;");
+
+export { render, reset };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@braintree/sanitize-url@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz#6110f918d273fe2af8ea1c4398a88774bb9fc12f"
+  integrity sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==
+
 "@monaco-editor/loader@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.3.2.tgz#04effbb87052d19cd7d3c9d81c0635490f9bb6d8"
@@ -60,7 +65,7 @@ browser-process-hrtime@^1.0.0:
 buffer-es6@^4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/buffer-es6/-/buffer-es6-4.9.3.tgz#f26347b82df76fd37e18bcb5288c4970cfd5c404"
-  integrity sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=
+  integrity sha512-Ibt+oXxhmeYJSsCkODPqNpPmyegefiD8rfutH1NYGhMZQhSp95Rz7haemgnJ6dxa6LT+JLLbtgOMORRluwKktw==
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -69,6 +74,316 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
+
+cose-base@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
+  integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
+  dependencies:
+    layout-base "^2.0.0"
+
+cytoscape-cose-bilkent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+  dependencies:
+    cose-base "^1.0.0"
+
+cytoscape-fcose@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
+  integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
+  dependencies:
+    cose-base "^2.2.0"
+
+cytoscape@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.23.0.tgz#054ee05a6d0aa3b4f139382bbf2f4e5226df3c6d"
+  integrity sha512-gRZqJj/1kiAVPkrVFvz/GccxsXhF3Qwpptl32gKKypO4IlqnKBjTOu+HbXtEggSGzC5KCaHp3/F7GgENrtsFkA==
+  dependencies:
+    heap "^0.2.6"
+    lodash "^4.17.21"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.2.tgz#f8ac4705c5b06914a7e0025bbf8d5f1513f6a86e"
+  integrity sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.2.tgz#7fd3717ad0eade2fc9939f4260acfb503f984e92"
+  integrity sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+d3-geo@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
+  integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-scale-chromatic@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.0.0, d3@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.8.2.tgz#2bdb3c178d095ae03b107a18837ae049838e372d"
+  integrity sha512-WXty7qOGSHb7HR7CfOzwN1Gw04MUOzN8qh9ZUsvwycIMb4DYMpY9xczZ6jUorGtO6bR9BPMPaueIKwiDxu9uiQ==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3-es@7.0.8:
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.8.tgz#14c309c3c08ba8329a7cf51000bd56a369c513d1"
+  integrity sha512-eykdoYQ4FwCJinEYS0gPL2f2w+BPbSLvnQSJ3Ye1vAoPjdkq6xIMKBv+UkICd3qZE26wBKIn3p+6n0QC7R1LyA==
+  dependencies:
+    d3 "^7.8.2"
+    lodash-es "^4.17.21"
+
+delaunator@5:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.0.tgz#60f052b28bd91c9b4566850ebf7756efe821d81b"
+  integrity sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==
+  dependencies:
+    robust-predicates "^3.0.0"
+
+dompurify@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.3.tgz#f4133af0e6a50297fc8874e2eaedc13a3c308c03"
+  integrity sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==
+
+elkjs@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.8.2.tgz#c37763c5a3e24e042e318455e0147c912a7c248e"
+  integrity sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==
 
 end-of-stream@^1.4.1:
   version "1.4.4"
@@ -218,6 +533,18 @@ fs-monkey@0.3.3:
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-0.3.3.tgz#7960bb2b1fa2653731b9d0e2e84812a7e8b3664a"
   integrity sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==
 
+heap@^0.2.6:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.7.tgz#1e6adf711d3f27ce35a81fe3b7bd576c2260a8fc"
+  integrity sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==
+
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -228,6 +555,36 @@ inherits@^2.0.3, inherits@^2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+khroma@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.0.0.tgz#7577de98aed9f36c7a474c4d453d94c0d6c6588b"
+  integrity sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g==
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
+
+layout-base@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
+  integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 memfs@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.0.4.tgz#17997ec34d67d0a4756f6a34f2fefd13a8dbab08"
@@ -236,10 +593,41 @@ memfs@3.0.4:
     fast-extend "1.0.2"
     fs-monkey "0.3.3"
 
+mermaid@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-9.4.0.tgz#ff9afcac9f565a358fa8fc39135dec2c842c3b8f"
+  integrity sha512-4PWbOND7CNRbjHrdG3WUUGBreKAFVnMhdlPjttuUkeHbCQmAHkwzSh5dGwbrKmXGRaR4uTvfFVYzUcg++h0DkA==
+  dependencies:
+    "@braintree/sanitize-url" "^6.0.0"
+    cytoscape "^3.23.0"
+    cytoscape-cose-bilkent "^4.1.0"
+    cytoscape-fcose "^2.1.0"
+    d3 "^7.0.0"
+    dagre-d3-es "7.0.8"
+    dompurify "2.4.3"
+    elkjs "^0.8.2"
+    khroma "^2.0.0"
+    lodash-es "^4.17.21"
+    moment "^2.29.4"
+    non-layered-tidy-tree-layout "^2.0.2"
+    stylis "^4.1.2"
+    ts-dedent "^2.2.0"
+    uuid "^9.0.0"
+
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 monaco-editor@^0.33.0:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.33.0.tgz#842e244f3750a2482f8a29c676b5684e75ff34af"
   integrity sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==
+
+non-layered-tidy-tree-layout@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz#57d35d13c356643fc296a55fb11ac15e74da7804"
+  integrity sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==
 
 once@^1.4.0:
   version "1.4.0"
@@ -282,15 +670,30 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+robust-predicates@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.1.tgz#ecde075044f7f30118682bd9fb3f123109577f9a"
+  integrity sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==
+
 ruby-head-wasm-wasi@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ruby-head-wasm-wasi/-/ruby-head-wasm-wasi-0.3.0.tgz#fcf9f07e34f8a48944bd5072ce92aebcce61f31a"
   integrity sha512-6EiZxeGZs8V7qPP7JhLxsg7e/Vmy3O4upQs8PcvMesXuH5r0XV0DIN6QII7Gd/5ot39tLL5VqAbi0zSefjaa7Q==
 
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
+
 safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 state-local@^1.0.6:
   version "1.0.7"
@@ -304,6 +707,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+stylis@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
+
 tar-stream@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
@@ -315,10 +723,20 @@ tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+ts-dedent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Related to https://github.com/ruby-syntax-tree/syntax_tree/issues/287

## Result
![image](https://user-images.githubusercontent.com/941776/219899215-9fdb6670-a393-4c77-8617-532667bd5cd7.png)
![image](https://user-images.githubusercontent.com/941776/219899232-3add164e-f409-479a-9f1a-e7205f68a12d.png)
![image](https://user-images.githubusercontent.com/941776/219899374-3624eee2-f7fd-45dd-867b-ca77e17e2675.png)

## Tasks
- [x] Update SyntaxTree
- [x] Add suport to mermaid.js
- [ ] Visualize CFG/DFG
- [ ] Visualize actual execution

## Improvements
- [ ] It would be nice to have zoom and drag and drop in graph visualization, similar to https://mermaid.live/
- [ ] Put some throttle when "source-changed" is dispatched to avoid too much rerendering