### PR TITLE
Visualize to_son (sea of nodes) using mermaid.js already added

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
             <option value="prettyPrint">AST</option>
             <option value="disasm">ISEQ</option>
             <option value="mermaid">GRAPH</option>
+            <option value="seaOfNodes">SEA OF NODES</option>
           </select>
         </div>
       </nav>

--- a/src/createRuby.js
+++ b/src/createRuby.js
@@ -25,17 +25,17 @@ export default async function createRuby() {
 
       return vm.eval(rubySource).toString();
     },
-    mermaid(source) {
-      const jsonSource = JSON.stringify(JSON.stringify(source));
-      const rubySource = `SyntaxTree.parse(JSON.parse(${jsonSource})).to_mermaid`;
-
-      return vm.eval(rubySource).toString();
-    },
     // A function that calls through to the SyntaxTree.format function to get
     // the pretty-printed version of the source.
     format(source) {
       const jsonSource = JSON.stringify(JSON.stringify(source));
       const rubySource = `SyntaxTree.format(JSON.parse(${jsonSource}))`;
+
+      return vm.eval(rubySource).toString();
+    },
+    mermaid(source) {
+      const jsonSource = JSON.stringify(JSON.stringify(source));
+      const rubySource = `SyntaxTree.parse(JSON.parse(${jsonSource})).to_mermaid`;
 
       return vm.eval(rubySource).toString();
     },
@@ -46,6 +46,17 @@ export default async function createRuby() {
       const rubySource = `PP.pp(SyntaxTree.parse(JSON.parse(${jsonSource})), +"", 80)`;
     
       return vm.eval(rubySource).toString();
-    }
+    },
+		// A function to print the current YARV execution
+		seaOfNodes(source) {
+      const jsonSource = JSON.stringify(JSON.stringify(source));
+      const rubySource = `
+				iseq = RubyVM::InstructionSequence.compile(JSON.parse(${jsonSource}))
+				iseq = SyntaxTree::YARV::InstructionSequence.from(iseq.to_a)
+				iseq.to_son.to_mermaid
+			`;
+
+      return vm.eval(rubySource).toString();
+		}
   };
 };

--- a/src/createRuby.js
+++ b/src/createRuby.js
@@ -47,16 +47,16 @@ export default async function createRuby() {
     
       return vm.eval(rubySource).toString();
     },
-		// A function to print the current YARV execution
-		seaOfNodes(source) {
+    // A function to print the current YARV execution
+    seaOfNodes(source) {
       const jsonSource = JSON.stringify(JSON.stringify(source));
       const rubySource = `
-				iseq = RubyVM::InstructionSequence.compile(JSON.parse(${jsonSource}))
-				iseq = SyntaxTree::YARV::InstructionSequence.from(iseq.to_a)
-				iseq.to_son.to_mermaid
-			`;
+        iseq = RubyVM::InstructionSequence.compile(JSON.parse(${jsonSource}))
+        iseq = SyntaxTree::YARV::InstructionSequence.from(iseq.to_a)
+        iseq.to_son.to_mermaid
+      `;
 
       return vm.eval(rubySource).toString();
-		}
+    }
   };
 };

--- a/src/createRuby.js
+++ b/src/createRuby.js
@@ -47,7 +47,7 @@ export default async function createRuby() {
     
       return vm.eval(rubySource).toString();
     },
-    // A function to print the current YARV execution
+    // A function to print the current sea of nodes
     seaOfNodes(source) {
       const jsonSource = JSON.stringify(JSON.stringify(source));
       const rubySource = `

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ Promise.all([
     try {
       let source = displayFunction(editor.getValue());
 
-      if (event.detail.kind === "mermaid") {
+      if (event.detail.kind === "mermaid" || event.detail.kind === "seaOfNodes") {
         output.setAttribute("style", "display: none;");
         graph.setAttribute("style", "text-align: left;")
         graph.innerHTML = "Loading..."


### PR DESCRIPTION
Related to https://github.com/ruby-syntax-tree/syntax_tree/issues/287

## Result
![image](https://user-images.githubusercontent.com/941776/228954648-7e74807e-de44-4393-9434-a4a08658af16.png)
![image](https://user-images.githubusercontent.com/941776/228955486-2c0716e0-fe67-48c9-b7f0-8bfa9e00595b.png)
